### PR TITLE
Fix ROS 2 user guide link text

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,7 +577,7 @@
 										<li><a href="https://archive.eclipse.org/tracecompass.incubator/doc/org.eclipse.tracecompass.incubator.opentracing.doc.user/User-Guide.html">OpenTracing Traces User Guide</a></li>
 										<li><a href="https://archive.eclipse.org/tracecompass.incubator/doc/org.eclipse.tracecompass.incubator.otf2.doc.user/User-Guide.html">Open Trace Format Version User Guide</a> </li>
 										<li><a href="https://archive.eclipse.org/tracecompass.incubator/doc/org.eclipse.tracecompass.incubator.ros.doc.user/User-Guide.html">Robot Operating System User Guide</a></li>
-   										<li><a href="https://archive.eclipse.org/tracecompass.incubator/doc/org.eclipse.tracecompass.incubator.ros2.doc.user/User-Guide.html">Robot Operating System v2 User Guide</a></li>
+										<li><a href="https://archive.eclipse.org/tracecompass.incubator/doc/org.eclipse.tracecompass.incubator.ros2.doc.user/User-Guide.html">Robot Operating System 2 User Guide</a></li>
 										<li><a href="https://archive.eclipse.org/tracecompass.incubator/doc/org.eclipse.tracecompass.incubator.scripting.doc.user/User-Guide.html">Trace Compass EASE Scripting User Guide</a></li>
 									</ul>
 							</li>


### PR DESCRIPTION
Just use '2' instead of 'v2'.