### PR TITLE
Replace .php links by equivalent (presumably static) page links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,11 @@ For issues related to the Trace Compass website, please open a GitHub tracker fo
 [code-of-conduct]: https://github.com/eclipse/.github/blob/master/CODE_OF_CONDUCT.md
 [commiter-handbook]: https://www.eclipse.org/projects/handbook/#resources-commit
 [dev-process]: https://eclipse.org/projects/dev_process
-[eca]: http://www.eclipse.org/legal/ECA.php
+[eca]: http://www.eclipse.org/legal/eca
 [ip-policy]: https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
 [issues]: https://github.com/eclipse-tracecompass/tracecompass-website/issues
 [mailing-list]: https://accounts.eclipse.org/mailing-list/tracecompass-dev
 [pr-guide]: #pull-request-guidelines
 [pull-requests]: https://github.com/eclipse-tracecompass/tracecompass-website/pulls
-[terms]: https://www.eclipse.org/legal/termsofuse.php
+[terms]: https://www.eclipse.org/legal/terms-of-use/
 [website]: https://github.com/eclipse-tracecompass/tracecompass-website

--- a/download.html
+++ b/download.html
@@ -291,11 +291,11 @@
 				<div class="col-md-6" style="text-align: center;">
 					<h3 style="color: white;">Legal</h3>
 					<ul style="list-style-type: none;">
-						<li><a href="//www.eclipse.org/legal/privacy.php">Privacy
+						<li><a href="//www.eclipse.org/legal/privacy/">Privacy
 								Policy</a></li>
-						<li><a href="//www.eclipse.org/legal/termsofuse.php">Terms
+						<li><a href="//www.eclipse.org/legal/terms-of-use/">Terms
 								of Use</a></li>
-						<li><a href="//www.eclipse.org/legal/copyright.php">Copyright
+						<li><a href="//www.eclipse.org/legal/copyright/">Copyright
 								Agent</a></li>
 						<li><a href="//www.eclipse.org/legal/">Legal Resources</a></li>
 						<li><a href="//www.eclipse.org/artwork/">Logo and Artwork</a></li>

--- a/index.html
+++ b/index.html
@@ -368,11 +368,6 @@
 
 								</ul></li>
 							<li>Linux <a href="https://www.kernel.org/doc/html/latest/trace/ftrace.html">FTrace</a> raw binary and textual format*</li>
-							<li>Hardware traces (e.g. IEEE Nexus 5001 CTF conversion).
-								See also <a
-								href="https://www.multicore-association.org/workgroup/tiwg.php">this
-									link</a>
-							</li>
 							<li><a
 								href="https://sourceware.org/gdb/onlinedocs/gdb/Tracepoints.html">GDB
 									traces</a> for debugging</li>
@@ -745,11 +740,11 @@
 				<div class="col-md-6" style="text-align: center;">
 					<h3 style="color: white;">Legal</h3>
 					<ul style="list-style-type: none;">
-						<li><a href="//www.eclipse.org/legal/privacy.php">Privacy
+						<li><a href="//www.eclipse.org/legal/privacy/">Privacy
 								Policy</a></li>
-						<li><a href="//www.eclipse.org/legal/termsofuse.php">Terms
+						<li><a href="//www.eclipse.org/legal/terms-of-use/">Terms
 								of Use</a></li>
-						<li><a href="//www.eclipse.org/legal/copyright.php">Copyright
+						<li><a href="//www.eclipse.org/legal/copyright/">Copyright
 								Agent</a></li>
 						<li><a href="//www.eclipse.org/legal/">Legal Resources</a></li>
 						<li><a href="//www.eclipse.org/artwork/">Logo and Artwork</a></li>


### PR DESCRIPTION
One Eclipse Foundation link does not seem to have a non-php link: the contact page.

Also removed a dead link to the multicore-association web site