### PR TITLE
update web page for Trace Compass 12.0.0 release

### DIFF
--- a/download.html
+++ b/download.html
@@ -109,7 +109,7 @@
 			<!-- Row -->
 			<div class="row">
 				<p>
-					<strong>Trace Compass 11.3.0</strong>, latest release (requires Java 21, a compatible JVM is included):
+					<strong>Trace Compass 12.0.0</strong>, latest release (requires Java 21, a compatible JVM is included):
 				</p>
 
 				<!-- downloads -->
@@ -122,7 +122,7 @@
 						</div>
 						<div class="price-btn">
 							<a title="Linux, 64-bit x86"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-linux.gtk.x86_64.tar.gz">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-linux.gtk.x86_64.tar.gz">
 								<button class="outline-btn">64-bit x86</button>
 							</a>
 						</div>
@@ -140,7 +140,7 @@
 						</div>
 						<div class="price-btn">
 							<a title="Windows, 64-bit x86"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-win32.win32.x86_64.zip">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-win32.win32.x86_64.zip">
 								<button class="outline-btn">64-bit x86</button>
 							</a>
 						</div>
@@ -158,13 +158,13 @@
 						</div>
 						<div class="price-btn">
 							<a title="OS X, 64-bit x86"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-macosx.cocoa.x86_64.dmg">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-macosx.cocoa.x86_64.dmg">
 								<button class="outline-btn">64-bit x86</button>
 							</a>
 						</div>
 						<div class="price-btn">
 							<a title="OS X, 64-bit ARM"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-macosx.cocoa.aarch64.dmg">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-macosx.cocoa.aarch64.dmg">
 								<button class="outline-btn">64-bit ARM</button>
 							</a>
 						</div>

--- a/index.html
+++ b/index.html
@@ -116,20 +116,20 @@
 							</p>
 							<noscript>
 								<a
-									href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-linux.gtk.x86_64.tar.gz">
+									href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-linux.gtk.x86_64.tar.gz">
 									<button class="main-btn">
-										Downloads <br> <strong>Trace Compass</strong> <strong>11.3.0</strong>
+										Downloads <br> <strong>Trace Compass</strong> <strong>12.0.0</strong>
 										&bull; Linux, 64-bit
 									</button>
 								</a>
 							</noscript>
 							<script type="text/javascript">
-								var versionNumber = '11.3.0';
+								var versionNumber = '12.0.0';
 								var versionFiles = {
-									linux64x86 : 'https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-linux.gtk.x86_64.tar.gz',
-									win64x86 : 'https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-win32.win32.x86_64.zip',
-									osx64x86 : 'https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-macosx.cocoa.x86_64.dmg',
-									osx64arm : 'https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-macosx.cocoa.aarch64.dmg'
+									linux64x86 : 'https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-linux.gtk.x86_64.tar.gz',
+									win64x86 : 'https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-win32.win32.x86_64.zip',
+									osx64x86 : 'https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-macosx.cocoa.x86_64.dmg',
+									osx64arm : 'https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-macosx.cocoa.aarch64.dmg'
 								};
 
 								var parser = new UAParser();
@@ -474,7 +474,7 @@
 						</div>
 						<div class="price-btn">
 							<a title="Linux, 64-bit x86"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-linux.gtk.x86_64.tar.gz">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-linux.gtk.x86_64.tar.gz">
 								<button class="outline-btn">64-bit x86</button>
 							</a>
 						</div>
@@ -492,7 +492,7 @@
 						</div>
 						<div class="price-btn">
 							<a title="Windows, 64-bit x86"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-win32.win32.x86_64.zip">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-win32.win32.x86_64.zip">
 								<button class="outline-btn">64-bit x86</button>
 							</a>
 						</div>
@@ -510,13 +510,13 @@
 						</div>
 						<div class="price-btn">
 							<a title="OS X, 64-bit x86"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-macosx.cocoa.x86_64.dmg">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-macosx.cocoa.x86_64.dmg">
 								<button class="outline-btn">64-bit x86</button>
 							</a>
 						</div>
 						<div class="price-btn">
 							<a title="OS X, 64-bit ARM"
-								href="https://download.eclipse.org/tracecompass/releases/11.3.0/rcp/trace-compass-11.3.0-20260409-1722-macosx.cocoa.aarch64.dmg">
+								href="https://download.eclipse.org/tracecompass/releases/12.0.0/rcp/trace-compass-12.0.0-20260610-0816-macosx.cocoa.aarch64.dmg">
 								<button class="outline-btn">64-bit ARM</button>
 							</a>
 						</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated download pages to reference Trace Compass version 12.0.0 as the latest release.
  * All platform-specific download links (Linux x86_64, Windows x86_64, macOS x86_64 and ARM64) now direct to version 12.0.0 release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->